### PR TITLE
🐛 Fix font rerender

### DIFF
--- a/src/index.jsx
+++ b/src/index.jsx
@@ -7,6 +7,7 @@ import App from './App';
 import theme from './styles/theme';
 import Globalstyle from './styles/GlobalStyle';
 import { store, persistor } from './app/configStore';
+import './styles/font.css';
 
 const root = ReactDOM.createRoot(document.getElementById('root'));
 root.render(

--- a/src/pages/GameRoom.jsx
+++ b/src/pages/GameRoom.jsx
@@ -175,7 +175,7 @@ function GameRoom() {
               color={({ theme }) => theme.colors.WHITE}
               bgcolor={({ theme }) => theme.colors.YELLOW_GREEN}
               shadow={({ theme }) => theme.colors.PAKISTAN_GREEN}
-              onClick{() => start()}
+              onClick={() => start()}
               width="100%"
               size="large"
               disabled={!allReady}

--- a/src/styles/GlobalStyle.js
+++ b/src/styles/GlobalStyle.js
@@ -1,28 +1,11 @@
 import reset from 'styled-reset';
 import { createGlobalStyle } from 'styled-components';
-import Pretendard from '../assets/fonts/PretendardVariable.woff2';
-import TTTogether from '../assets/fonts/TTTogether.otf';
 
 const Globalstyle = createGlobalStyle`
 ${reset}
 
-@font-face {
-  font-family: 'Pretendard';
-  src: url(${Pretendard});
-}
-
-@font-face {
-  font-family: 'TTTogether';
-  src: url(${TTTogether});
-}
-
 * {
-    font-family: 'Pretendard', sans-serif;
     box-sizing: border-box;
-}
-
-body {
-    font-family: 'Pretendard', sans-serif;
 }
 
 ol, ul {

--- a/src/styles/font.css
+++ b/src/styles/font.css
@@ -1,0 +1,18 @@
+@font-face {
+  font-family: 'Pretendard';
+  src: url('../assets/fonts/PretendardVariable.woff2');
+}
+
+@font-face {
+  font-family: 'TTTogether';
+  src: url('../assets/fonts/TTTogether.otf');
+}
+
+* {
+  font-family: 'Pretendard', sans-serif;
+}
+
+body {
+  font-family: 'Pretendard', sans-serif;
+}
+


### PR DESCRIPTION
### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 관련 이슈
https://github.com/Trys-Ketch/trys-ketch-client/issues/23#issue-1549092775

### 반영 브랜치
fix/fontrender-> dev

### 변경 사항
계속해서 폰트가 리렌더링 되면서 느려지던 문제 해결
js 내부에서 선언하던 폰트를 css 파일로 분리후에 index.js 에 import하는 방식으로 해결

### 테스트 결과
최초에만 렌더링이 일어
![ezgif com-gif-maker (3)](https://user-images.githubusercontent.com/57736547/213451700-fbea7603-97f0-487a-b427-066aa0d77bea.gif)
나는 것을 확인했습니다.

