### PR TITLE
:necktie: Reset Drawing state

### DIFF
--- a/src/components/painting/Paint.jsx
+++ b/src/components/painting/Paint.jsx
@@ -31,6 +31,7 @@ function Paint({
   submitImg,
   completeImageSubmit,
   image,
+  gameState,
 }) {
   const thickness = [5, 7, 9, 11, 13];
   const color = [
@@ -303,6 +304,26 @@ function Paint({
       context.lineWidth = thickness[0] * 2;
 
       setCtx(() => context);
+    }
+  }, [isDrawingState]);
+
+  useEffect(() => {
+    if (isDrawingState) {
+      const canvas = canvasRef.current;
+      const context = canvas.getContext('2d');
+
+      currentColor = 'black';
+      context.strokeStyle = 'black';
+      context.lineWidth = thickness[0] * 2;
+      context.globalCompositeOperation = 'source-over';
+      setCtx(() => context);
+
+      historyPointer = 0;
+      history.splice(0);
+
+      setEventState('drawing');
+      setDisplayThicknessBtn(false);
+      setNowThickness(0);
     }
   }, [isDrawingState]);
 

--- a/src/pages/GameRoom.jsx
+++ b/src/pages/GameRoom.jsx
@@ -166,7 +166,9 @@ function GameRoom() {
 
   useEffect(() => {
     const client = new Stomp.Client({
-      debug: (str) => {},
+      debug: (str) => {
+        console.log(str);
+      },
       splitLargeFrames: true,
       webSocketFactory: () => new SockJS(`${process.env.REACT_APP_API_URL}/ws`),
     });
@@ -185,6 +187,7 @@ function GameRoom() {
     client.onDisconnect = (frame) => {
       dispatch(closeStomp());
     };
+
     dispatch(setStomp(client));
     return () => {
       if (client) {


### PR DESCRIPTION
게임 상태가 Drawing이 되면 기존의 캔버스 관련 데이터를 초기화 했습니다.

### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
feature/ingame -> dev

### 변경 사항
Drwaing 상태가 되면 캔버스가 이전의 데이터를 유지하지 않고 새롭게 초기화하도록 수정했습니다.

### 테스트 결과
모두 제대로 초기화 되는 것을 확인했습니다.
