### PR TITLE
:necktie: Update muteuser logic

### DIFF
--- a/src/app/slices/ingameSlice.js
+++ b/src/app/slices/ingameSlice.js
@@ -6,6 +6,7 @@ const initialState = {
   socket: null,
   isHost: false,
   forceSubmit: false,
+  reconnect: () => {},
 };
 
 const ingameSlice = createSlice({
@@ -41,6 +42,10 @@ const ingameSlice = createSlice({
       ...state,
       forceSubmit: action.payload,
     }),
+    setReconnect: (state, action) => ({
+      ...state,
+      // reconnect: action.payload,
+    }),
   },
   extraReducers: {},
 });
@@ -53,5 +58,6 @@ export const {
   closeStomp,
   setIngameHost,
   setForceSubmit,
+  setReconnect,
 } = ingameSlice.actions;
 export default ingameSlice.reducer;

--- a/src/app/slices/muteSlice.js
+++ b/src/app/slices/muteSlice.js
@@ -2,6 +2,7 @@ import { createSlice } from '@reduxjs/toolkit';
 
 const initialState = {
   users: [],
+  connectedUsers: [],
   localMute: false,
 };
 
@@ -12,6 +13,10 @@ const muteSlice = createSlice({
     setMuteUsers: (state, action) => ({
       ...state,
       users: [...action.payload],
+    }),
+    setConnectedMuteUser: (state, action) => ({
+      ...state,
+      connectedUsers: action.payload,
     }),
     setMute: (state, action) => {
       const newUsers = [];
@@ -36,11 +41,13 @@ const muteSlice = createSlice({
     }),
     clearMute: () => ({
       users: [],
+      connectedUsers: [],
       localMute: false,
     }),
   },
   extraReducers: {},
 });
 
-export const { setMuteUsers, setMute, setLocalMute, clearMute } = muteSlice.actions;
+export const { setMuteUsers, setConnectedMuteUser, setMute, setLocalMute, clearMute } =
+  muteSlice.actions;
 export default muteSlice.reducer;

--- a/src/components/mute/MuteUserList.jsx
+++ b/src/components/mute/MuteUserList.jsx
@@ -4,18 +4,10 @@ import styled from 'styled-components';
 import MuteUser from './MuteUser';
 
 function MuteUserList({ socketID }) {
-  const users = useSelector((state) => state.mute.users);
-  // const users = [
-  //   {
-  //     nickname: '미안하다이거보여주려고어그로끌었다나루토사스케싸움수준ㄹㅇ실화냐',
-  //     socketID: 'wq192v3r',
-  //     isMuted: false,
-  //   },
-  //   { nickname: '네임2', socketID: '3eu1o29b', isMuted: true },
-  // ];
+  const users = useSelector((state) => state.mute.connectedUsers);
   return (
     <div>
-      {users.length !== 1 && (
+      {users.length !== 0 && (
         <UserList>
           {users.map((v) => {
             return socketID !== v.socketID && <MuteUser key={v.socketID} user={v} />;

--- a/src/components/webRTC/Audio.jsx
+++ b/src/components/webRTC/Audio.jsx
@@ -2,6 +2,8 @@ import React, { useEffect, useRef, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { setMuteUsers } from '../../app/slices/muteSlice';
 
+const localAttendee = null;
+
 function Audio({ stream, socketID }) {
   const ref = useRef(null);
   const users = useSelector((state) => state.mute.users);
@@ -12,12 +14,6 @@ function Audio({ stream, socketID }) {
   useEffect(() => {
     if (ref.current) ref.current.srcObject = stream;
   }, [stream]);
-
-  useEffect(() => {
-    return () => {
-      dispatch(setMuteUsers(users.filter((v) => v.socketID !== socketID)));
-    };
-  }, []);
 
   return (
     <audio ref={ref} muted={isMuted} autoPlay>


### PR DESCRIPTION
rtc연결이 활성화 된 경우에만 muteuser에 보이게 수정, webRTC 연결이 잘 안되던 버그 수정

### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
feature/webRTC -> dev

### 변경 사항
muteuser를 표시하는 방식이 기존 attendee 전부에서 rtc연결이 된 유저만으로 변경 (Closes #116)
muteuser 표시 방식을 변경하는 과정에서 (#111) 이슈도 해결 (Closes #111)
rtc 연결이 잘 안되던 버그 수정 (예상) (Closes #115 )

### 테스트 결과
muteuser 표시는 잘 되는것을 확인했습니다.
webRTC 연결은 추가적인 테스트가 필요해보입니다. (일단 제가 해봤을 땐 잘 됩니다.)
