### PR TITLE
:necktie: Connect webRTC when error on getUserMedia

### DIFF
--- a/src/components/modal/DescriptionModal.jsx
+++ b/src/components/modal/DescriptionModal.jsx
@@ -13,8 +13,8 @@ function DiscriptionModal() {
       <DiscriptionText>아직은 미완성이라서, 다음 사항들은 양해 부탁드려요&#x1F625;</DiscriptionText>
       <BoldText>음성채팅이 원활하지 않을 경우 해결 방법</BoldText>
       <DiscriptionText>
-        {`1. 방을 나간 다음에 새로고침하고 다시 들어와주세요
-2. 그래도 연결이 되지 않으면 현재 창을 닫고 새로운 창으로 접속 부탁드려요`}
+        {`1. 브라우저의 마이크 접근 권한을 허가해주세요
+2. 허가하지 않으면 다른 유저들이 플레이어님의 말을 들을 수 없어요!`}
       </DiscriptionText>
       <BoldText>제한시간 관련</BoldText>
       <DiscriptionText>

--- a/src/components/webRTC/AudioCall.tsx
+++ b/src/components/webRTC/AudioCall.tsx
@@ -10,6 +10,7 @@ import { store } from '../../app/configStore';
 import usePreventRefresh from '../../hooks/usePreventRefresh';
 import { clearMute, setConnectedMuteUser, setMuteUsers } from '../../app/slices/muteSlice';
 import usePreventGoBack from '../../hooks/usePreventGoBack';
+import { toast } from '../toast/ToastProvider';
 
 let pcs: any;
 let hasPcs: any;
@@ -136,6 +137,8 @@ function AudioCall() {
       })
       .catch((error) => {
         getUserMediaState = 'rejected';
+        toast.error('음성 채팅 연결 에러');
+        toast.error('다른 유저들이 플레이어님의 말을 들을 수 없어요!');
       });
   }, []);
 
@@ -181,7 +184,7 @@ function AudioCall() {
               // eslint-disable-next-line
               await sleep(300);
             }
-            if (getUserMediaState === 'rejected') return;
+            // if (getUserMediaState === 'rejected') return;
 
             hasPcs = { ...hasPcs, [allUsers[i].id]: false };
             // i번째 유저와 나의 peer connection 생성
@@ -225,7 +228,7 @@ function AudioCall() {
             // eslint-disable-next-line
             await sleep(300);
           }
-          if (getUserMediaState === 'rejected') return;
+          // if (getUserMediaState === 'rejected') return;
 
           hasPcs = { ...hasPcs, [data.sender]: false };
           // offer를 요청한 상대방과의 peer connection을 생성합니다.


### PR DESCRIPTION
로컬 미디어를 가져오는 상황에서 문제가 생겨도 rtc연결을 하게 수정, 로컬미디어에 문제가 있으면 toast를 띄우게 수정했습니다.

### PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [x] 업데이트

### 반영 브랜치
feature/webRTC -> dev

### 변경 사항
미디어스트림이 사용 불가능해도 webRTC에 연결 가능하게 수정
그러나 자신의 말을 다른 유저가 들을 수 없으므로 toast로 알리고 description modal에 해당 내용 추가

### 테스트 결과
마이크 접근 권한 거부하고 방에 들어가면 의도된 대로 toast가 출력되고, webRTC 연결이 유지되는 것을 확인했습니다.
